### PR TITLE
fix: the db creds injected through secret manager issue in the load env

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -57,6 +57,9 @@ func FileName() string {
 }
 
 func LoadEnv() error {
+	const (
+		localEnvFile = "local"
+	)
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		return fmt.Errorf("Error getting current file path")
@@ -71,18 +74,16 @@ func LoadEnv() error {
 
 	envName := os.Getenv("ENVIRONMENT_NAME")
 	if envName == "" {
-		envName = "local"
+		envName = localEnvFile
 	}
 	log.Println("envName: " + envName)
 
 	envVarInjection := GetBool("ENV_INJECTION")
-	if !envVarInjection || envName == "local" {
+	if !envVarInjection || envName == localEnvFile {
 		err = godotenv.Load(fmt.Sprintf("%s.env.%s", prefix, envName))
 
 		if err != nil {
-			fmt.Printf(".env.%s\n", envName)
-			log.Println(err)
-			return err
+			return fmt.Errorf("couldn't load .env.%s file: %w", envName, err)
 		}
 		fmt.Println("loaded", fmt.Sprintf("%s.env.%s", prefix, envName))
 		return nil
@@ -90,26 +91,43 @@ func LoadEnv() error {
 
 	dbCredsInjected := GetBool("COPILOT_DB_CREDS_VIA_SECRETS_MANAGER")
 
-	if dbCredsInjected {
-		type copilotSecrets struct {
-			Username string `json:"username"`
-			Host     string `json:"host"`
-			DBName   string `json:"dbname"`
-			Password string `json:"password"`
-			Port     int    `json:"port"`
-		}
-		secrets := &copilotSecrets{}
-
-		err := json.Unmarshal([]byte(os.Getenv("DB_SECRET")), secrets)
-		if err != nil {
-			return err
-		}
-
-		os.Setenv("PSQL_DBNAME", secrets.DBName)
-		os.Setenv("PSQL_HOST", secrets.Host)
-		os.Setenv("PSQL_PASS", secrets.Password)
-		os.Setenv("PSQL_PORT", strconv.Itoa(secrets.Port))
-		os.Setenv("PSQL_USER", secrets.Username)
+	// except for local environment the db creds should be
+	// injected through the secret manager
+	if envName != localEnvFile && !dbCredsInjected {
+		return fmt.Errorf("db creds should be injected through secret manager")
 	}
-	return fmt.Errorf("COPILOT_DB_CREDS_VIA_SECRETS_MANAGER should have had a value")
+
+	// for local environment the db configs will be loaded through
+	// env itself by `godotenv`, even if db creds are not injected
+	if !dbCredsInjected {
+		return nil
+	}
+
+	// if dbCreds is injected then extract the db creds
+	return extractDBCredsFromSecret()
+}
+
+// extractDBCredsFromSecret helper function to extract db secret
+func extractDBCredsFromSecret() error {
+	type copilotSecrets struct {
+		Username string `json:"username"`
+		Host     string `json:"host"`
+		DBName   string `json:"dbname"`
+		Password string `json:"password"`
+		Port     int    `json:"port"`
+	}
+	secrets := &copilotSecrets{}
+
+	err := json.Unmarshal([]byte(os.Getenv("DB_SECRET")), secrets)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal db secret: %w", err)
+	}
+
+	os.Setenv("PSQL_DBNAME", secrets.DBName)
+	os.Setenv("PSQL_HOST", secrets.Host)
+	os.Setenv("PSQL_PASS", secrets.Password)
+	os.Setenv("PSQL_PORT", strconv.Itoa(secrets.Port))
+	os.Setenv("PSQL_USER", secrets.Username)
+
+	return nil
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"go-template/pkg/utl/convert"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 
 	"github.com/joho/godotenv"
+
+	"go-template/pkg/utl/convert"
 )
 
 func GetString(key string) string {
@@ -81,9 +82,8 @@ func LoadEnv() error {
 	envVarInjection := GetBool("ENV_INJECTION")
 	if !envVarInjection || envName == localEnvFile {
 		err = godotenv.Load(fmt.Sprintf("%s.env.%s", prefix, envName))
-
 		if err != nil {
-			return fmt.Errorf("couldn't load .env.%s file: %w", envName, err)
+			return fmt.Errorf("failed load env for environment %q file: %w", envName, err)
 		}
 		fmt.Println("loaded", fmt.Sprintf("%s.env.%s", prefix, envName))
 		return nil
@@ -97,14 +97,12 @@ func LoadEnv() error {
 		return fmt.Errorf("db creds should be injected through secret manager")
 	}
 
-	// for local environment the db configs will be loaded through
-	// env itself by `godotenv`, even if db creds are not injected
-	if !dbCredsInjected {
-		return nil
+	// if db creds are injected, extract those
+	if dbCredsInjected {
+		return extractDBCredsFromSecret()
 	}
-
-	// if dbCreds is injected then extract the db creds
-	return extractDBCredsFromSecret()
+	// otherwise
+	return nil
 }
 
 // extractDBCredsFromSecret helper function to extract db secret

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -2,12 +2,12 @@ package config_test
 
 import (
 	"fmt"
-	. "go-template/internal/config"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	. "go-template/internal/config"
 )
 
 func TestGetString(t *testing.T) {
@@ -42,7 +42,6 @@ func TestGetString(t *testing.T) {
 			if tt.success {
 				os.Setenv(tt.args.key, tt.want)
 			}
-			time.Sleep(time.Microsecond)
 
 			if got := GetString(tt.args.key); got != tt.want {
 				t.Errorf("GetString() = %v, want %v", got, tt.want)
@@ -499,7 +498,8 @@ func testLoadEnv(t *testing.T, tt struct {
 	name    string
 	wantErr bool
 	args    args
-}) {
+},
+) {
 	if err := LoadEnv(); (err != nil) != tt.wantErr {
 		t.Errorf("LoadEnv() error = %v, wantErr %v", err, tt.wantErr)
 	} else {


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
- It fixes the loading of the Db credentials from the secret manager for local env

### Steps to Reproduce / Test
---------------------------------------------------
- `go test -gcflags=all=-l go-template/internal/config -run TestLoadEnv`

### Request
---------------------------------------------------


### Response
---------------------------------------------------


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when loading environment files to ensure smoother application startup.
  
- **Refactor**
  - Enhanced management of environment variables and database credentials, leading to more reliable configuration handling.

- **Tests**
  - Extended test coverage to include new scenarios for environment and database credential handling, ensuring robustness and reliability in various configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->