### PR TITLE
feat: add keploy coverage support

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -13,3 +13,5 @@ REDIS_ADDRESS=redis:6379
 COPILOT_DB_CREDS_VIA_SECRETS_MANAGER=false
 SERVER_PORT=9000
 ENV_INJECTION=false
+APP_PATH=/Users/charankamarapu/wednesday/go-template
+GOCOVERDIR=coverage-reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.22-alpine3.19 AS builder
 RUN apk add build-base
 
-RUN mkdir  /app
-ADD . /app
+ARG APP_PATH
 
-WORKDIR /app
+RUN mkdir -p ${APP_PATH}
+ADD . ${APP_PATH}
+
+WORKDIR ${APP_PATH}
 ARG ENVIRONMENT_NAME 
 ENV ENVIRONMENT_NAME=$ENVIRONMENT_NAME
 RUN GOARCH=amd64 \
@@ -14,39 +16,47 @@ RUN GOARCH=amd64 \
 
 
 RUN go run ./cmd/seeder/main.go
-RUN go build -o ./output/server ./cmd/server/main.go
-RUN go build -o ./output/migrations ./cmd/migrations/main.go
-RUN go build  -o ./output/seeder ./cmd/seeder/exec/seed.go
+RUN go build -cover -o ./output/server ./cmd/server/main.go
+RUN go build -cover -o ./output/migrations ./cmd/migrations/main.go
+RUN go build -cover -o ./output/seeder ./cmd/seeder/exec/seed.go
 
 
 FROM alpine:latest
 RUN apk add --no-cache libc6-compat 
 RUN apk add --no-cache --upgrade bash
+RUN apk add --no-cache dumb-init
 RUN addgroup -S nonroot \
     && adduser -S nonroot -G nonroot
 
-
+ARG APP_PATH
 ARG ENVIRONMENT_NAME
 ENV ENVIRONMENT_NAME=$ENVIRONMENT_NAME
 
-RUN mkdir -p /app/
-WORKDIR /app
+RUN echo ${APP_PATH}
+RUN mkdir -p ${APP_PATH}/
+WORKDIR ${APP_PATH}
+
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Clean the coverage-reports folder
 USER nonroot
 
-COPY /scripts /app/scripts/
-COPY --from=builder /app/output/ /app/
-COPY --from=builder /app/cmd/seeder/exec/build/ /app/cmd/seeder/exec/build/
+COPY /scripts ${APP_PATH}/scripts/
+COPY --from=builder ${APP_PATH}/output/ ${APP_PATH}/
+COPY --from=builder ${APP_PATH}/cmd/seeder/exec/build/ ${APP_PATH}/cmd/seeder/exec/build/
 
-COPY ./.env.* /app/output/
-COPY ./.env.* /app/output/cmd/seeder/exec/build/
-COPY ./.env.* /app/output/cmd/seeder/exec/
-COPY ./.env.* /app/output/cmd/seeder/
-COPY ./.env.* /app/output/cmd/
-COPY ./.env.* /app/
-COPY ./scripts/ /app/
-COPY --from=builder /app/internal/migrations/ /app/internal/migrations/
-CMD ["bash","./migrate-and-run.sh"]
+COPY ./.env.* ${APP_PATH}/output/
+COPY ./.env.* ${APP_PATH}/output/cmd/seeder/exec/build/
+COPY ./.env.* ${APP_PATH}/output/cmd/seeder/exec/
+COPY ./.env.* ${APP_PATH}/output/cmd/seeder/
+COPY ./.env.* ${APP_PATH}/output/cmd/
+COPY ./.env.* ${APP_PATH}/
+COPY ./scripts/ ${APP_PATH}/
+COPY --from=builder ${APP_PATH}/internal/migrations/ ${APP_PATH}/internal/migrations/
 
-
+ENTRYPOINT ["dumb-init", "--"]
+STOPSIGNAL SIGINT
+CMD ["/entrypoint.sh"]
 EXPOSE 9000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   db:
@@ -6,7 +6,7 @@ services:
     restart: always
     env_file:
       - .env.docker
-    
+
     environment:
       - POSTGRES_USER=${PSQL_USER}
       - POSTGRES_PASSWORD=${PSQL_PASS}
@@ -26,7 +26,12 @@ services:
     command: tcp db:${PSQL_PORT} -t 30s -i 250ms
 
   app:
-    build: .
+    build: 
+      context: .
+      args:
+        APP_PATH: ${APP_PATH}
+    image: go-template_app:latest
+    container_name: got
     restart: always
     env_file:
       - ./.env.${ENVIRONMENT_NAME}
@@ -35,5 +40,8 @@ services:
         condition: service_completed_successfully
     ports:
       - ${SERVER_PORT}:${SERVER_PORT}
+    volumes:
+      - ${APP_PATH}/coverage-reports:${APP_PATH}/coverage-reports
     environment:
-      ENVIRONMENT_NAME:  ${ENVIRONMENT_NAME}
+      ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
+    stop_grace_period: 50s

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Clean the coverage-reports folder
+rm -rf ./coverage-reports/*
+
+# Run your application or migration script
+exec bash ./migrate-and-run.sh

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	controller "go-template/internal/controller"
@@ -91,7 +92,7 @@ func Start(e *echo.Echo, cfg *Config) {
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 10 seconds.
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
+	signal.Notify(quit, syscall.SIGINT)
 	<-quit
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer func() {

--- a/scripts/migrate-and-run.sh
+++ b/scripts/migrate-and-run.sh
@@ -2,6 +2,19 @@
 
 echo $ENVIRONMENT_NAME
 
+handle_int() {
+     echo "SIGINT received, forwarding to child process..."
+     kill -INT "$child" 2>/dev/null
+     echo "Waiting for child process to exit..."
+     wait "$child"
+     echo "Child process exited. Waiting for coverage data to be fully written..."
+     echo "Exiting after delay..."
+     exit 0
+ }
+
+ # Trap SIGINT signal   
+ trap 'handle_int' INT TERM
+
 ./migrations
 
 if [[ $ENVIRONMENT_NAME == "docker" ]]; then
@@ -9,4 +22,10 @@ if [[ $ENVIRONMENT_NAME == "docker" ]]; then
     ./seeder
 fi
 
-./server
+./server &
+
+child=$!
+echo "Started process with PID $child"
+
+ # Wait for child process to finish
+wait "$child"


### PR DESCRIPTION
Please follow the below steps to get keploy coverage for go-template in docker.

1. Pull the branch for  some changes related to stop signals, mounts, path references.
2. Please provide your project path in place of APP_PATH in .env.dcoker.
3. Run keploy test command
4. Run this cmd `go tool covdata textfmt -i="./coverage-reports" -o=complete-coverage.txt`

Coverage :

- To get coverage per file in html run this - `go tool cover -html complete-coverage.txt`   
- To get total coverage as prompt run this - `go tool cover -func complete-coverage.txt | grep total:`
- To get coverage function wise run this - `go tool cover -func complete-coverage.txt`
