### PR TITLE
Fix/env load

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -57,6 +57,9 @@ func FileName() string {
 }
 
 func LoadEnv() error {
+	const (
+		localEnvFile = "local"
+	)
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		return fmt.Errorf("Error getting current file path")
@@ -71,18 +74,16 @@ func LoadEnv() error {
 
 	envName := os.Getenv("ENVIRONMENT_NAME")
 	if envName == "" {
-		envName = "local"
+		envName = localEnvFile
 	}
 	log.Println("envName: " + envName)
 
 	envVarInjection := GetBool("ENV_INJECTION")
-	if !envVarInjection || envName == "local" {
+	if !envVarInjection || envName == localEnvFile {
 		err = godotenv.Load(fmt.Sprintf("%s.env.%s", prefix, envName))
 
 		if err != nil {
-			fmt.Printf(".env.%s\n", envName)
-			log.Println(err)
-			return err
+			return fmt.Errorf("couldn't load .env.%s file: %w", envName, err)
 		}
 		fmt.Println("loaded", fmt.Sprintf("%s.env.%s", prefix, envName))
 		return nil
@@ -90,26 +91,43 @@ func LoadEnv() error {
 
 	dbCredsInjected := GetBool("COPILOT_DB_CREDS_VIA_SECRETS_MANAGER")
 
-	if dbCredsInjected {
-		type copilotSecrets struct {
-			Username string `json:"username"`
-			Host     string `json:"host"`
-			DBName   string `json:"dbname"`
-			Password string `json:"password"`
-			Port     int    `json:"port"`
-		}
-		secrets := &copilotSecrets{}
-
-		err := json.Unmarshal([]byte(os.Getenv("DB_SECRET")), secrets)
-		if err != nil {
-			return err
-		}
-
-		os.Setenv("PSQL_DBNAME", secrets.DBName)
-		os.Setenv("PSQL_HOST", secrets.Host)
-		os.Setenv("PSQL_PASS", secrets.Password)
-		os.Setenv("PSQL_PORT", strconv.Itoa(secrets.Port))
-		os.Setenv("PSQL_USER", secrets.Username)
+	// except for local environment the db creds should be
+	// injected through the secret manager
+	if envName != localEnvFile && !dbCredsInjected {
+		return fmt.Errorf("db creds should be injected through secret manager")
 	}
-	return fmt.Errorf("COPILOT_DB_CREDS_VIA_SECRETS_MANAGER should have had a value")
+
+	// for local environment the db configs will be loaded through
+	// env itself by `godotenv`, even if db creds are not injected
+	if !dbCredsInjected {
+		return nil
+	}
+
+	// if dbCreds is injected then extract the db creds
+	return extractDBCredsFromSecret()
+}
+
+// extractDBCredsFromSecret helper function to extract db secret
+func extractDBCredsFromSecret() error {
+	type copilotSecrets struct {
+		Username string `json:"username"`
+		Host     string `json:"host"`
+		DBName   string `json:"dbname"`
+		Password string `json:"password"`
+		Port     int    `json:"port"`
+	}
+	secrets := &copilotSecrets{}
+
+	err := json.Unmarshal([]byte(os.Getenv("DB_SECRET")), secrets)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal db secret: %w", err)
+	}
+
+	os.Setenv("PSQL_DBNAME", secrets.DBName)
+	os.Setenv("PSQL_HOST", secrets.Host)
+	os.Setenv("PSQL_PASS", secrets.Password)
+	os.Setenv("PSQL_PORT", strconv.Itoa(secrets.Port))
+	os.Setenv("PSQL_USER", secrets.Username)
+
+	return nil
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"go-template/pkg/utl/convert"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 
 	"github.com/joho/godotenv"
+
+	"go-template/pkg/utl/convert"
 )
 
 func GetString(key string) string {
@@ -81,9 +82,8 @@ func LoadEnv() error {
 	envVarInjection := GetBool("ENV_INJECTION")
 	if !envVarInjection || envName == localEnvFile {
 		err = godotenv.Load(fmt.Sprintf("%s.env.%s", prefix, envName))
-
 		if err != nil {
-			return fmt.Errorf("couldn't load .env.%s file: %w", envName, err)
+			return fmt.Errorf("failed load env for environment %q file: %w", envName, err)
 		}
 		fmt.Println("loaded", fmt.Sprintf("%s.env.%s", prefix, envName))
 		return nil
@@ -97,14 +97,12 @@ func LoadEnv() error {
 		return fmt.Errorf("db creds should be injected through secret manager")
 	}
 
-	// for local environment the db configs will be loaded through
-	// env itself by `godotenv`, even if db creds are not injected
-	if !dbCredsInjected {
-		return nil
+	// if db creds are injected, extract those
+	if dbCredsInjected {
+		return extractDBCredsFromSecret()
 	}
-
-	// if dbCreds is injected then extract the db creds
-	return extractDBCredsFromSecret()
+	// otherwise
+	return nil
 }
 
 // extractDBCredsFromSecret helper function to extract db secret

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -63,7 +63,7 @@ func LoadEnv() error {
 	)
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
-		return fmt.Errorf("Error getting current file path")
+		return fmt.Errorf("error getting current file path")
 	}
 
 	prefix := fmt.Sprintf("%s/", filepath.Join(filepath.Dir(filename), "../../"))
@@ -83,7 +83,7 @@ func LoadEnv() error {
 	if !envVarInjection || envName == localEnvFile {
 		err = godotenv.Load(fmt.Sprintf("%s.env.%s", prefix, envName))
 		if err != nil {
-			return fmt.Errorf("failed load env for environment %q file: %w", envName, err)
+			return fmt.Errorf("failed to load env for environment %q file: %w", envName, err)
 		}
 		fmt.Println("loaded", fmt.Sprintf("%s.env.%s", prefix, envName))
 		return nil
@@ -114,9 +114,13 @@ func extractDBCredsFromSecret() error {
 		Password string `json:"password"`
 		Port     int    `json:"port"`
 	}
-	secrets := &copilotSecrets{}
+	secrets, dbSecret := &copilotSecrets{}, os.Getenv("DB_SECRET")
 
-	err := json.Unmarshal([]byte(os.Getenv("DB_SECRET")), secrets)
+	if dbSecret == "" {
+		return fmt.Errorf("'DB_SECRET' environment var is not set or is empty")
+	}
+
+	err := json.Unmarshal([]byte(dbSecret), secrets)
 	if err != nil {
 		return fmt.Errorf("couldn't unmarshal db secret: %w", err)
 	}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -2,12 +2,12 @@ package config_test
 
 import (
 	"fmt"
-	. "go-template/internal/config"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	. "go-template/internal/config"
 )
 
 func TestGetString(t *testing.T) {
@@ -42,7 +42,6 @@ func TestGetString(t *testing.T) {
 			if tt.success {
 				os.Setenv(tt.args.key, tt.want)
 			}
-			time.Sleep(time.Microsecond)
 
 			if got := GetString(tt.args.key); got != tt.want {
 				t.Errorf("GetString() = %v, want %v", got, tt.want)
@@ -499,7 +498,8 @@ func testLoadEnv(t *testing.T, tt struct {
 	name    string
 	wantErr bool
 	args    args
-}) {
+},
+) {
 	if err := LoadEnv(); (err != nil) != tt.wantErr {
 		t.Errorf("LoadEnv() error = %v, wantErr %v", err, tt.wantErr)
 	} else {

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -367,34 +367,6 @@ func loadOnDbCredsInjectedInDevEnv(
 	}
 }
 
-func errorOnDbCredsInjectedInLocalEnv() envTestCaseArgs {
-	return envTestCaseArgs{
-		name:    "dbCredsInjected True for `local` environment, with invalid json in db secret",
-		wantErr: true,
-		args: args{
-			setEnv: []keyValueArgs{
-				{
-					key:   "ENV_INJECTION",
-					value: "true",
-				},
-				{
-					key:   "ENVIRONMENT_NAME",
-					value: "develop",
-				},
-				{
-					key:   "COPILOT_DB_CREDS_VIA_SECRETS_MANAGER",
-					value: "true",
-				},
-				{
-					key:   "DB_SECRET",
-					value: `invalid json`,
-				},
-			},
-			expectedKeyValues: []keyValueArgs{},
-		},
-	}
-}
-
 func loadDbCredsInjectedInLocalEnv(
 	username string,
 	host string,
@@ -482,7 +454,6 @@ func getTestCases(username string, host string, dbname string, password string, 
 		loadOnCopilotTrueAndLocalEnv(),
 		errorOnDbCredsInjectedInDevEnv(),
 		loadOnDbCredsInjectedInDevEnv(username, host, dbname, password, port),
-		errorOnDbCredsInjectedInLocalEnv(),
 		loadDbCredsInjectedInLocalEnv(username, host, dbname, password, port),
 		errorOnWrongEnvName(),
 	}


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
* It fixes the loading of the Db credentials from the secret manager for local env


### Steps to Reproduce / Test
---------------------------------------------------
* `go test -gcflags=all=-l go-template/internal/config -run TestLoadEnv`


### Request
---------------------------------------------------


### Response
---------------------------------------------------


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling for loading environment variables with more descriptive messages.
	- Added functionality to extract database credentials from a secret manager for non-local environments.

- **Bug Fixes**
	- Enhanced tests to cover various scenarios for loading environment variables and handling database credentials.

- **Tests**
	- Introduced new test cases for different environment settings and error conditions related to database credential management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->